### PR TITLE
Fix & update babel setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "stage": 0,
-  "optional": "runtime"
+  presets: ['stage-0', 'es2015'],
+  plugins: ['babel-plugin-transform-runtime']
 }

--- a/package.json
+++ b/package.json
@@ -27,17 +27,20 @@
   },
   "homepage": "https://github.com/alexkuz/redux-pagan",
   "devDependencies": {
-    "babel": "^5.8.21",
-    "babel-core": "^5.4.7",
-    "babel-eslint": "^4.0.10",
-    "babel-loader": "^5.1.2",
-    "babel-runtime": "^5.8.20",
-    "eslint": "^1.2.1",
+    "babel-cli": "^6.9.0",
+    "babel-core": "^6.9.1",
+    "babel-eslint": "^6.0.4",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-transform-runtime": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "eslint": "^2.11.1",
     "eslint-loader": "^1.0.0",
-    "eslint-plugin-babel": "^2.1.1"
+    "eslint-plugin-babel": "^3.2.0"
   },
   "dependencies": {
-    "lodash.memoize": "^3.0.4"
+    "babel-runtime": "^6.9.2",
+    "lodash.memoize": "^4.0.1"
   },
   "peerDependencies": {
     "intl-messageformat": "^1.1.0"


### PR DESCRIPTION
Otherwise when using redux-pagan from an es2015 setup, regenerator runtime is included in a wrong way. It tries to do something along the lines of `require('regenerator-runtime').default` but regenerator-runtime doesn't export with default, i.e. it doesn't use es6 style modules yet. 
