### PR TITLE
Upgrade to babel 6.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "stage": 0,
-  "optional": "runtime"
+  "presets": ["es2015", "stage-0"],
+  "plugins": ["transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -27,14 +27,15 @@
   },
   "homepage": "https://github.com/alexkuz/redux-pagan",
   "devDependencies": {
-    "babel": "^5.8.21",
-    "babel-core": "^5.4.7",
-    "babel-eslint": "^4.0.10",
-    "babel-loader": "^5.1.2",
-    "babel-runtime": "^5.8.20",
-    "eslint": "^1.2.1",
+    "babel-cli": "^6.0.0",
+    "babel-core": "^6.0.0",
+    "babel-eslint": "^6.0.0",
+    "babel-runtime": "^6.0.0",
+    "babel-preset-es2015": "^6.0.0",
+    "babel-preset-stage-0": "^6.0.0",
+    "babel-plugin-transform-runtime": "^6.0.0",
     "eslint-loader": "^1.0.0",
-    "eslint-plugin-babel": "^2.1.1"
+    "eslint-plugin-babel": "^3.2.0"
   },
   "dependencies": {
     "lodash.memoize": "^3.0.4"


### PR DESCRIPTION
Babel 6.something made a module change moving "babel-runtime/regenerator" out of default. Because of this redux-pagan failed on _regenerator undefined. Rebuilding with babel 6 makes it work again.
